### PR TITLE
ci: add scan provider agents ci

### DIFF
--- a/.github/workflows/scan-provider-agents.yaml
+++ b/.github/workflows/scan-provider-agents.yaml
@@ -1,0 +1,49 @@
+name: scan-provider-agents
+
+on:
+  pull_request:
+    paths:
+      - 'cvmassistants/secretprovider/secret-provider-agent/src/secret_provider_agent.c'
+      - 'cvmassistants/keyprovider/key-provider-agent/src/key_provider_agent.c'
+  workflow_dispatch: {}
+
+jobs:
+  scan-provider-agents:
+
+    name: Scan ${{ matrix.provider-agent.file }}
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        provider-agent:
+          - dir: cvmassistants/secretprovider/secret-provider-agent/src
+            file: secret_provider_agent.c
+          - dir: cvmassistants/keyprovider/key-provider-agent/src
+            file: key_provider_agent.c
+      
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools directly
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format cppcheck
+
+      - name: Check if file changed
+        id: changed
+        uses: tj-actions/changed-files@v47
+        with:
+          files: ${{ matrix.provider-agent.dir }}/${{ matrix.provider-agent.file }}
+
+      - name: clang-format scan ${{ matrix.provider-agent.file }}
+        if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
+        working-directory: ${{ matrix.provider-agent.dir }}
+        run: |
+          clang-format --dry-run -style=llvm --Werror ${{ matrix.provider-agent.file }}
+
+      - name: cppcheck scan ${{ matrix.provider-agent.file }}
+        if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
+        working-directory: ${{ matrix.provider-agent.dir }}
+        run: | # enable all checks and suppress missing include system since RATS-TLS dependencies are not included in the repo
+          cppcheck --enable=all --suppress=missingIncludeSystem --error-exitcode=1 ${{ matrix.provider-agent.file }}

--- a/.github/workflows/scan-provider-agents.yaml
+++ b/.github/workflows/scan-provider-agents.yaml
@@ -22,13 +22,20 @@ jobs:
           - dir: cvmassistants/keyprovider/key-provider-agent/src
             file: key_provider_agent.c
       
+    permissions:
+      security-events: write
+      contents: write
+      actions: read
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Install tools directly
+      - name: Install cppcheck
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-format cppcheck
+          sudo apt-get install -y cppcheck
 
       - name: Check if file changed
         id: changed
@@ -38,12 +45,36 @@ jobs:
 
       - name: clang-format scan ${{ matrix.provider-agent.file }}
         if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
-        working-directory: ${{ matrix.provider-agent.dir }}
-        run: |
-          clang-format --dry-run -style=llvm --Werror ${{ matrix.provider-agent.file }}
+        uses: DoozyX/clang-format-lint-action@v0.18.2
+        with:
+          source: ${{ matrix.provider-agent.dir }}/${{ matrix.provider-agent.file }}
+          style: llvm
+          inplace: True
 
-      - name: cppcheck scan ${{ matrix.provider-agent.file }}
+      - uses: EndBug/add-and-commit@v9
+        with:
+          author_name: Clang Robot
+          author_email: robot@example.com
+          message: 'fix: action - committing clang-format changes'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: cppcheck scan ${{ matrix.provider-agent.file }} 
         if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         working-directory: ${{ matrix.provider-agent.dir }}
-        run: | # enable all checks and suppress missing include system since RATS-TLS dependencies are not included in the repo
-          cppcheck --enable=all --suppress=missingIncludeSystem --error-exitcode=1 ${{ matrix.provider-agent.file }}
+        run: |
+          cppcheck --enable=all --suppress=missingIncludeSystem --xml --output-file=report.xml ${{ matrix.provider-agent.file }}
+
+      - name: Convert cppcheck XML → SARIF
+        if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: Flast/cppcheck-sarif@v2
+        with:
+          input: ${{ matrix.provider-agent.dir }}/report.xml
+          output: ${{ matrix.provider-agent.dir }}/report.sarif
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ matrix.provider-agent.dir }}/report.sarif
+          category: cppcheck

--- a/.github/workflows/scan-provider-agents.yaml
+++ b/.github/workflows/scan-provider-agents.yaml
@@ -24,7 +24,7 @@ jobs:
       
     permissions:
       security-events: write
-      contents: write
+      contents: read
       actions: read
 
     steps:
@@ -42,20 +42,15 @@ jobs:
         uses: tj-actions/changed-files@v47
         with:
           files: ${{ matrix.provider-agent.dir }}/${{ matrix.provider-agent.file }}
-
+      
+      # correct using: clang-format -style=llvm -i ${{ matrix.provider-agent.dir }}/${{ matrix.provider-agent.file }}
       - name: clang-format scan ${{ matrix.provider-agent.file }}
         if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: DoozyX/clang-format-lint-action@v0.18.2
         with:
           source: ${{ matrix.provider-agent.dir }}/${{ matrix.provider-agent.file }}
           style: llvm
-          inplace: True
-
-      - uses: EndBug/add-and-commit@v9
-        with:
-          message: 'fix: action - committing clang-format changes'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          inplace: False
 
       - name: cppcheck scan ${{ matrix.provider-agent.file }} 
         if: steps.changed.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/scan-provider-agents.yaml
+++ b/.github/workflows/scan-provider-agents.yaml
@@ -53,8 +53,6 @@ jobs:
 
       - uses: EndBug/add-and-commit@v9
         with:
-          author_name: Clang Robot
-          author_email: robot@example.com
           message: 'fix: action - committing clang-format changes'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Runs on PRs that modify provider agent C files, or manually via workflow_dispatch.

**Scanned files:** (number of parallel jobs)
- secret_provider_agent.c
- key_provider_agent.c

**Workflow:**
- Checks if file changed - Skips scans if the specific file wasn't modified
- clang-format - Validates code formatting (LLVM style) and auto-commits fixes
- cppcheck - Static analysis for bugs, undefined behavior, and code quality issues
- SARIF report - Uploads cppcheck results to GitHub Code Scanning for inline annotations ("Security" tab)